### PR TITLE
Replace v3 calls with the regular call

### DIFF
--- a/sync_integration_test.go
+++ b/sync_integration_test.go
@@ -30,7 +30,7 @@ var _ = Describe("Syncing", func() {
 
 			It("restarts processes missing from diego", func() {
 				appName := generator.PrefixedRandomName("SITS", "APP")
-				Expect(cf.Cf("push", appName, "--no-start", "-d", testConfig.GetAppsDomain(), "-s", "cflinuxfs3", "-p", "fixtures/dora", "-b", "ruby_buildpack").Wait(Timeout)).To(Exit(0))
+				Expect(cf.Cf("push", appName, "--no-start", "-s", "cflinuxfs3", "-p", "fixtures/dora", "-b", "ruby_buildpack").Wait(Timeout)).To(Exit(0))
 				Expect(cf.Cf("start", appName).Wait(PushTimeout)).To(Exit(0))
 
 				Eventually(func() string {
@@ -49,7 +49,7 @@ var _ = Describe("Syncing", func() {
 
 			It("refreshes stale processes", func() {
 				appName := generator.PrefixedRandomName("SITS", "APP")
-				Expect(cf.Cf("push", appName, "--no-start", "-d", testConfig.GetAppsDomain(), "-s", "cflinuxfs3", "-p", "fixtures/dora", "-b", "ruby_buildpack").Wait(Timeout)).To(Exit(0))
+				Expect(cf.Cf("push", appName, "--no-start", "-s", "cflinuxfs3", "-p", "fixtures/dora", "-b", "ruby_buildpack").Wait(Timeout)).To(Exit(0))
 				Expect(cf.Cf("start", appName).Wait(PushTimeout)).To(Exit(0))
 
 				Eventually(func() string {
@@ -91,7 +91,7 @@ var _ = Describe("Syncing", func() {
 
 			It("cancels processes that should not be running according to CC", func() {
 				appName := generator.PrefixedRandomName("SITS", "APP")
-				Expect(cf.Cf("push", appName, "--no-start", "-d", testConfig.GetAppsDomain(), "-s", "cflinuxfs3", "-p", "fixtures/dora", "-b", "ruby_buildpack").Wait(Timeout)).To(Exit(0))
+				Expect(cf.Cf("push", appName, "--no-start", "-s", "cflinuxfs3", "-p", "fixtures/dora", "-b", "ruby_buildpack").Wait(Timeout)).To(Exit(0))
 				Expect(cf.Cf("start", appName).Wait(PushTimeout)).To(Exit(0))
 
 				Eventually(func() string {
@@ -191,7 +191,7 @@ var _ = Describe("Syncing", func() {
 					newCommand = fmt.Sprintf(`{"command": "%s"}`, "TEST_VAR=fake bundle exec rackup config.ru -p $PORT")
 					cf.Cf("curl", fmt.Sprintf("/v3/processes/%s", webProcessGuid), "-X", "PATCH", "-d", newCommand)
 					Expect(cf.Cf("set-env", appName, "FOO", "og_bar").Wait(ShortTimeout)).To(Exit(0))
-					Expect(cf.Cf("set-droplet", appName, "-d", ogDoraGuid).Wait(ShortTimeout)).To(Exit(0))
+					Expect(cf.Cf("set-droplet", appName, ogDoraGuid).Wait(ShortTimeout)).To(Exit(0))
 
 					processGuid := GetProcessGuid(appName)
 					DeleteProcessGuidFromDiego(processGuid)
@@ -229,7 +229,7 @@ var _ = Describe("Syncing", func() {
 					It("restores its sidecar when it's restarted", func() {
 						appName := generator.PrefixedRandomName("SITS", "APP")
 
-						Expect(cf.Cf("push", appName, "--no-start", "-d", testConfig.GetAppsDomain(), "-s", "cflinuxfs3", "-p", "fixtures/dora", "-b", "ruby_buildpack").Wait(Timeout)).To(Exit(0))
+						Expect(cf.Cf("push", appName, "--no-start", "-s", "cflinuxfs3", "-p", "fixtures/dora", "-b", "ruby_buildpack").Wait(Timeout)).To(Exit(0))
 						appGUID := helpers.GetAppGuid(appName)
 						helpers.CreateSidecar("my_sidecar", []string{"web"}, "sleep 100000", appGUID)
 						Expect(cf.Cf("start", appName).Wait(PushTimeout)).To(Exit(0))
@@ -276,7 +276,7 @@ var _ = Describe("Syncing", func() {
 		Describe("Route syncing", func() {
 			It("Adds missing routes to copilot", func() {
 				appName := generator.PrefixedRandomName("SITS", "APP")
-				Expect(cf.Cf("push", appName, "--no-start", "-d", testConfig.GetAppsDomain(), "-s", "cflinuxfs3", "-p", "fixtures/dora", "-b", "ruby_buildpack", "--hostname", appName).Wait(Timeout)).To(Exit(0))
+				Expect(cf.Cf("push", appName, "--no-start", "-s", "cflinuxfs3", "-p", "fixtures/dora", "-b", "ruby_buildpack", "--hostname", appName).Wait(Timeout)).To(Exit(0))
 				Expect(cf.Cf("start", appName).Wait(PushTimeout)).To(Exit(0))
 
 				Eventually(func() string {
@@ -413,7 +413,7 @@ var _ = Describe("Syncing", func() {
 			Describe("CAPIDiegoProcessAssociation syncing", func() {
 				It("Adds missing CAPI Diego Process Associations to copilot", func() {
 					appName := generator.PrefixedRandomName("SITS", "APP")
-					Expect(cf.Cf("push", appName, "--no-start", "-d", testConfig.GetAppsDomain(), "-s", "cflinuxfs3", "-p", "fixtures/dora", "-b", "ruby_buildpack").Wait(Timeout)).To(Exit(0))
+					Expect(cf.Cf("push", appName, "--no-start", "-s", "cflinuxfs3", "-p", "fixtures/dora", "-b", "ruby_buildpack").Wait(Timeout)).To(Exit(0))
 					Expect(cf.Cf("start", appName).Wait(PushTimeout)).To(Exit(0))
 
 					Eventually(func() string {

--- a/sync_integration_test.go
+++ b/sync_integration_test.go
@@ -152,7 +152,7 @@ var _ = Describe("Syncing", func() {
 					revisionsEnablePath := fmt.Sprintf("/v3/apps/%s/features/revisions", appGuid)
 					Expect(cf.Cf("curl", revisionsEnablePath, "-X", "PATCH", "-d", `{"enabled": true}`).Wait(ShortTimeout)).To(Exit(0))
 
-					Expect(cf.Cf("v3-restart", appName).Wait(PushTimeout)).To(Exit(0))
+					Expect(cf.Cf("restart", appName).Wait(PushTimeout)).To(Exit(0))
 
 					Eventually(func() string {
 						body, _ := CurlAppRoot(appName)
@@ -168,8 +168,8 @@ var _ = Describe("Syncing", func() {
 					webProcessGuid := GetCCProcessGuidsForType(appGuid, "web")[0]
 					newCommand := fmt.Sprintf(`{"command": "%s"}`, "TEST_VAR=real bundle exec rackup config.ru -p $PORT")
 					cf.Cf("curl", fmt.Sprintf("/v3/processes/%s", webProcessGuid), "-X", "PATCH", "-d", newCommand)
-					Expect(cf.Cf("v3-set-env", appName, "FOO", "ng_bar").Wait(ShortTimeout)).To(Exit(0))
-					Expect(cf.Cf("v3-push", appName, "-p", "fixtures/other-dora", "-b", "ruby_buildpack").Wait(PushTimeout)).To(Exit(0))
+					Expect(cf.Cf("set-env", appName, "FOO", "ng_bar").Wait(ShortTimeout)).To(Exit(0))
+					Expect(cf.Cf("push", appName, "-p", "fixtures/other-dora", "-b", "ruby_buildpack").Wait(PushTimeout)).To(Exit(0))
 
 					Eventually(func() string {
 						body, _ := CurlAppRoot(appName)
@@ -190,8 +190,8 @@ var _ = Describe("Syncing", func() {
 					webProcessGuid = GetCCProcessGuidsForType(appGuid, "web")[0]
 					newCommand = fmt.Sprintf(`{"command": "%s"}`, "TEST_VAR=fake bundle exec rackup config.ru -p $PORT")
 					cf.Cf("curl", fmt.Sprintf("/v3/processes/%s", webProcessGuid), "-X", "PATCH", "-d", newCommand)
-					Expect(cf.Cf("v3-set-env", appName, "FOO", "og_bar").Wait(ShortTimeout)).To(Exit(0))
-					Expect(cf.Cf("v3-set-droplet", appName, "-d", ogDoraGuid).Wait(ShortTimeout)).To(Exit(0))
+					Expect(cf.Cf("set-env", appName, "FOO", "og_bar").Wait(ShortTimeout)).To(Exit(0))
+					Expect(cf.Cf("set-droplet", appName, "-d", ogDoraGuid).Wait(ShortTimeout)).To(Exit(0))
 
 					processGuid := GetProcessGuid(appName)
 					DeleteProcessGuidFromDiego(processGuid)


### PR DESCRIPTION
- v3 is when v6 cli was used. We shouldn't be using v6


I was attempting to figure out why only elsa is super flaky with these tests.  I don't have an answer to that, but was surprised to see v3 calls in the cli.  Turns out we're using cf cli v6, which we shouldn't

corresponding dockerfile change - https://github.com/cloudfoundry/capi-dockerfiles/pull/34