### PR TITLE
Use cf-deployment-concourse-tasks image

### DIFF
--- a/concourse/README.md
+++ b/concourse/README.md
@@ -1,1 +1,0 @@
-The Dockerfile for this task now lives at https://github.com/cloudfoundry/capi-dockerfiles/tree/master/sits

--- a/concourse/task.sh
+++ b/concourse/task.sh
@@ -78,6 +78,8 @@ mkdir -p "${GOPATH}/src/code.cloudfoundry.org"
 cp -a sync-integration-tests "${GOPATH}/src/code.cloudfoundry.org"
 
 pushd "${GOPATH}/src/code.cloudfoundry.org/sync-integration-tests" > /dev/null
+  go install github.com/onsi/ginkgo/v2/ginkgo
+
   ginkgo -nodes="${NODES}" --flake-attempts="${FLAKE_ATTEMPTS}"
 popd > /dev/null
 

--- a/concourse/task.yml
+++ b/concourse/task.yml
@@ -3,8 +3,7 @@ platform: linux
 image_resource:
   type: registry-image
   source:
-    repository: cloudfoundry/capi
-    tag: sits
+    repository: cloudfoundry/cf-deployment-concourse-tasks
 
 inputs:
   - name: sync-integration-tests

--- a/concourse/task_with_credhub.yml
+++ b/concourse/task_with_credhub.yml
@@ -4,8 +4,7 @@ platform: linux
 image_resource:
   type: registry-image
   source:
-    repository: cloudfoundry/capi
-    tag: sits
+    repository: cloudfoundry/cf-deployment-concourse-tasks
 
 inputs:
   - name: sync-integration-tests

--- a/concourse/task_with_vars_store.yml
+++ b/concourse/task_with_vars_store.yml
@@ -3,8 +3,7 @@ platform: linux
 image_resource:
   type: registry-image
   source:
-    repository: cloudfoundry/capi
-    tag: sits
+    repository: cloudfoundry/cf-deployment-concourse-tasks
 
 inputs:
   - name: sync-integration-tests


### PR DESCRIPTION
The `cf-deployment-concourse-tasks` docker image contains everything that is needed by SITS except Ginkgo, which is now installed as part of the task.